### PR TITLE
user login: show "not verified" vs "incorrect credentials" message

### DIFF
--- a/application/default/controllers/LoginController.php
+++ b/application/default/controllers/LoginController.php
@@ -29,9 +29,9 @@ class LoginController extends ControllerAbstract
             $strPassword = trim($this->getRequest()->getPost('password'));
             $blnRemember = (int) $this->getRequest()->getPost('remember', 0);
             $intAttempts = (int) $this->getRequest()->getPost('attempts', 0);
+            $userExists  = Users::isActiveUser($strUsername);
 
             // assign view variables
-
             $this->view->strUsername = $strUsername;
             $this->view->intAttempts = $intAttempts + 1;
 
@@ -57,7 +57,11 @@ class LoginController extends ControllerAbstract
                     $this->_redirect('/');
 
                 } else if ($intResult == -3) {
-                    $this->_helper->FlashMessenger(array('danger' => 'Your account is not active yet. A confirmation email with an activation link has been sent.'));
+                    if ($userExists) {
+                        $this->_helper->FlashMessenger(array('danger' => 'Sorry, those credentials were not valid. Try again or reset your password.'));
+                    } else {
+                        $this->_helper->FlashMessenger(array('danger' => 'Your account is not active yet. A confirmation email with an activation link has been sent.'));
+                    }
                 } else {
                     $this->_helper->FlashMessenger(array('danger' => 'Login failed. Please try again.'));
                 }

--- a/application/models/users.phpm
+++ b/application/models/users.phpm
@@ -47,7 +47,7 @@ class Users extends Myriad_Table
                 'username',
                 'password',
                 'MD5(CONCAT(?, password_salt)) AND user_is_active = 1'
-                // 'MD5(CONCAT(?, password_salt))'
+            // 'MD5(CONCAT(?, password_salt))'
             );
 
             $objAuthAdapter->setIdentity($strUsername);
@@ -141,6 +141,25 @@ class Users extends Myriad_Table
         $objSelect->from('tbl_users', array('total' => 'count(*)'));
         $objSelect->where('username = ?', $strEmail);
         // $objSelect->where('user_status = 1');
+        $objSelect->limit(1);
+
+        try {
+            return Myriad_Data::getAdapter()->fetchOne($objSelect->__toString());
+        } catch (Myriad_Exception $e) {
+            Myriad_Log::getInstance()->writeLog($e->getMessage(), Zend_Log::ERR);
+        }
+    }
+
+    /**
+     * Is Active User
+     */
+
+    public static function isActiveUser($strEmail = '')
+    {
+        $objSelect = Myriad_Data::getAdapter()->select();
+        $objSelect->from('tbl_users', array('total' => 'count(*)'));
+        $objSelect->where('username = ?', $strEmail);
+        $objSelect->where('user_is_active = 1');
         $objSelect->limit(1);
 
         try {


### PR DESCRIPTION
Resolves issue:

```
When someone typed in a wrong password, it said that they never confirmed their password in their email instead of just saying they had the wrong password
```